### PR TITLE
fix: channel not created when moving from existing channel

### DIFF
--- a/apps/server/src/bot/events/onVoiceStateUpdate.ts
+++ b/apps/server/src/bot/events/onVoiceStateUpdate.ts
@@ -31,7 +31,6 @@ export default new Event('voiceStateUpdate', async (_client, before, after) => {
   if (before.channelId === null && after.channelId && after.member && after.channel) {
     eventMemberJoin(after.member.id)
 
-    const voiceRoomCreateChannel = await getSetting('voiceRoomCreateChannel')
     if (after.channelId === voiceRoomCreateChannel) {
       await voiceChannelCreate(after.member)
       return
@@ -48,6 +47,12 @@ export default new Event('voiceStateUpdate', async (_client, before, after) => {
     }
 
     await sendAlert(before.channel as TextBasedChannel, 'leave', before.member)
+
+    if (after.channelId === voiceRoomCreateChannel) {
+      await voiceChannelCreate(after.member)
+      return
+    }
+
     await sendAlert(after.channel as TextBasedChannel, 'join', after.member)
     return
   }


### PR DESCRIPTION
기존에 있던 음성 채널에서 `통화방 생성 채널`로 이동할 때 통화방이 생성되지 않는 버그가 있습니다.

또한 추가로 음성 채널 생성 시 생성한 유저에게 해당 음성 채널에 대한 권한 (채널명 수정, 인원수 제한)을 주면 좋을 것 같습니다.
버튼을 눌러서 변경할 경우 5분 30초마다 바꿀 수 있기 때문에 실수로 잘못 변경한 경우 다시 변경하기 불편하고, 음성 채널을 변경할 수 있는 버튼이 채널 맨 위에 있기 때문에 채팅이 많이 쌓이면 다시 올려서 변경하는 것이 힘듭니다.