### PR TITLE
fix(server): Redis MISCONF 시 캐시 계층 graceful degradation 및 설정 유실 방지 (#16)

### DIFF
--- a/apps/server/src/bot/interactions/modals/voice-rename.ts
+++ b/apps/server/src/bot/interactions/modals/voice-rename.ts
@@ -1,7 +1,7 @@
 import { ChannelType, MessageFlags } from 'discord.js'
 
 import { Modal } from '~/bot/base/interaction'
-import { redis } from '~/lib/redis'
+import { cacheSet } from '~/lib/redis'
 import {
   findChatroomRule,
   redisVoiceRenameRateExpire,
@@ -41,7 +41,8 @@ export default new Modal('modal.voice-rename', async (client, interaction) => {
 
   await interaction.deferUpdate({})
 
-  await redis.set(
+  // rate-limit 마커는 보조 용도이므로 쓰기 실패(MISCONF 등) 시에도 이름 변경 흐름을 막지 않는다.
+  await cacheSet(
     redisVoiceRenameRateKey(interaction.channel.id),
     '1',
     'EX',

--- a/apps/server/src/lib/redis.ts
+++ b/apps/server/src/lib/redis.ts
@@ -19,9 +19,30 @@ declare global {
   var redis: Redis | undefined
 }
 
-console.log('REDIS CONNECT', config)
+/**
+ * 연결이 끊겼을 때 점진적으로 재시도한다. (최대 5초 간격)
+ */
+const retryStrategy = (times: number) => Math.min(times * 200, 5000)
 
-export const redis = global.redis || new Redis(config.redisURL)
+/**
+ * 네트워크 수준 오류에서만 재연결을 시도한다.
+ *
+ * 참고: MISCONF(RDB 스냅샷 실패로 인한 쓰기 차단)는 연결 오류가 아니라 명령 수준 응답 오류이므로
+ * reconnectOnError로는 제어할 수 없다(재연결해도 디스크 문제는 그대로다). MISCONF에 대한 실제
+ * 방어선은 아래 cacheSet/cacheGet의 try-catch이며, 이 콜백은 READONLY/네트워크 단절 시 재연결만 담당한다.
+ */
+const reconnectOnError = (err: Error) => {
+  const recoverable = ['READONLY', 'ETIMEDOUT', 'ECONNRESET']
+  return recoverable.some((target) => err.message.includes(target))
+}
+
+export const redis =
+  global.redis ||
+  new Redis(config.redisURL, {
+    retryStrategy,
+    reconnectOnError,
+    maxRetriesPerRequest: 3,
+  })
 
 if (process.env.NODE_ENV !== 'production') global.redis = redis
 
@@ -32,3 +53,47 @@ redis.on('connect', () => {
 redis.on('error', (err) => {
   logger.error(err.message)
 })
+
+/**
+ * 캐시 용도의 Redis 쓰기를 best-effort로 수행한다.
+ *
+ * RDB 스냅샷 실패(MISCONF)나 연결 장애 등으로 쓰기가 차단되더라도, 캐시는 보조 저장소이므로
+ * 호출부의 주 로직(주로 DB 조회 결과 반환)을 막아서는 안 된다. 오류를 삼키고 경고만 남긴 뒤
+ * 성공 여부를 boolean으로 반환한다.
+ *
+ * @returns 쓰기 성공 여부
+ */
+export const cacheSet = async (
+  key: string,
+  value: string | number,
+  mode: 'EX',
+  duration: number,
+): Promise<boolean> => {
+  try {
+    await redis.set(key, value, mode, duration)
+    return true
+  } catch (err) {
+    logger.warn(
+      `cache write skipped for "${key}": ${err instanceof Error ? err.message : String(err)}`,
+    )
+    return false
+  }
+}
+
+/**
+ * 캐시 용도의 Redis 읽기를 best-effort로 수행한다.
+ *
+ * Redis 미가용 시 오류를 던지는 대신 null을 반환하여 호출부가 원본 저장소(DB)로 fallback할 수 있게 한다.
+ */
+export const cacheGet = async (key: string): Promise<string | null> => {
+  try {
+    return await redis.get(key)
+  } catch (err) {
+    logger.warn(
+      `cache read failed for "${key}", falling back: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    )
+    return null
+  }
+}

--- a/apps/server/src/service/gallery.ts
+++ b/apps/server/src/service/gallery.ts
@@ -1,7 +1,7 @@
 import { dbClient } from '@ideaslab/db'
 
 import config from '~/config'
-import { redis } from '~/lib/redis'
+import { cacheGet, cacheSet } from '~/lib/redis'
 
 const redisGalleryCategoryKey = (channelId: string) => `${config.redisPrefix}gallery:${channelId}`
 
@@ -16,7 +16,7 @@ const redisExpire = 60 * 60 * 24 // 24 hours
  * if (!categoryId) return
  */
 export const getGalleryCategory = async (channelId: string) => {
-  const cached = await redis.get(redisGalleryCategoryKey(channelId))
+  const cached = await cacheGet(redisGalleryCategoryKey(channelId))
   if (cached) return parseInt(cached)
 
   const category = await dbClient.category.findUnique({
@@ -30,7 +30,8 @@ export const getGalleryCategory = async (channelId: string) => {
 
   if (!category) return null
 
-  await redis.set(redisGalleryCategoryKey(channelId), category.id, 'EX', redisExpire)
+  // 캐시 갱신 실패가 조회 결과 반환을 막지 않도록 best-effort로 처리한다.
+  await cacheSet(redisGalleryCategoryKey(channelId), category.id, 'EX', redisExpire)
 
   return category.id
 }

--- a/apps/server/src/service/setting.ts
+++ b/apps/server/src/service/setting.ts
@@ -1,7 +1,7 @@
 import { dbClient } from '@ideaslab/db'
 
 import config from '~/config'
-import { redis } from '~/lib/redis'
+import { cacheGet, cacheSet } from '~/lib/redis'
 
 enum SettingValueType {
   String = 'string',
@@ -132,9 +132,8 @@ export const setSetting = async <T extends SettingKeys>(
 ) => {
   const stringified = JSON.stringify(value)
 
-  if (settingDetails[key].cache)
-    await redis.set(redisSettingKey(key), stringified, 'EX', settingKeyExpire)
-
+  // DB가 원본(source of truth)이므로 먼저 기록한다.
+  // 캐시 쓰기를 먼저 하면 MISCONF 등으로 캐시가 막혔을 때 DB 기록까지 차단되어 설정이 유실된다.
   await dbClient.setting.upsert({
     where: { key },
     create: {
@@ -145,20 +144,28 @@ export const setSetting = async <T extends SettingKeys>(
       value: stringified,
     },
   })
+
+  // 캐시는 보조 저장소이므로 실패해도 무시한다.
+  // 트레이드오프: 캐시 쓰기가 실패하면 기존 캐시 값이 TTL 만료(1일)까지 남아 일시적 불일치가 생길 수 있다.
+  // MISCONF 상황에서는 DEL(쓰기 명령)도 함께 차단되므로 무효화로 해결되지 않아, best-effort 갱신만 시도한다.
+  if (settingDetails[key].cache)
+    await cacheSet(redisSettingKey(key), stringified, 'EX', settingKeyExpire)
 }
 
 export const getSetting = async <T extends SettingKeys>(
   key: SettingKeys,
 ): Promise<SettingValueTypeConvert<(typeof SettingList)[T]> | null> => {
-  let value: any = null
-  if (settingDetails[key].cache) value = await redis.get(redisSettingKey(key))
+  let value: string | null = null
+  // 캐시 읽기 실패 시 null로 처리되어 아래 DB 조회로 fallback된다.
+  if (settingDetails[key].cache) value = await cacheGet(redisSettingKey(key))
 
   if (value === null) {
     const data = await dbClient.setting.findUnique({ where: { key } })
     if (!data) return null
 
+    // 캐시 갱신 실패가 DB 조회 결과 반환을 막지 않도록 best-effort로 처리한다.
     if (settingDetails[key].cache)
-      await redis.set(redisSettingKey(key), data.value, 'EX', settingKeyExpire)
+      await cacheSet(redisSettingKey(key), data.value, 'EX', settingKeyExpire)
 
     return JSON.parse(data.value)
   }

--- a/apps/server/src/service/voice-channel/index.ts
+++ b/apps/server/src/service/voice-channel/index.ts
@@ -18,7 +18,7 @@ import {
 
 import { currentGuild, currentGuildChannel } from '~/bot/base/client'
 import { EmbedColor } from '~/bot/types'
-import { redis } from '~/lib/redis'
+import { cacheSet } from '~/lib/redis'
 import { hexToRgb } from '~/utils'
 
 import { getSetting } from '../setting.js'
@@ -119,7 +119,8 @@ export const voiceChannelSetRule = async (
     //   `[${rule?.emoji} ${rule?.name}] ${channel.name.split('] ').slice(1).join('] ')}`,
     // )
     await channel.setName(`[${rule?.emoji ?? '.'}] ${channel.name.split('] ').slice(1).join('] ')}`)
-    await redis.set(redisVoiceRenameRateKey(channel.id), '1', 'EX', redisVoiceRenameRateExpire)
+    // 이름 변경 rate-limit 마커는 보조 용도이므로 실패해도 무시한다.
+    await cacheSet(redisVoiceRenameRateKey(channel.id), '1', 'EX', redisVoiceRenameRateExpire)
   }
 
   return data

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,10 @@ services:
     restart: always
     ports:
       - '6379:6379'
-    command: redis-server --save 20 1 --loglevel warning
+    # RDB 스냅샷(--save) 대신 AOF를 사용한다.
+    # RDB는 stop-writes-on-bgsave-error 기본값(yes)으로 인해 스냅샷 실패 시 모든 쓰기가 차단되어
+    # MISCONF 오류를 유발한다(issue #16). AOF는 더 fault-tolerant하며 --save ""로 RDB를 비활성화해 차단을 제거한다.
+    command: redis-server --appendonly yes --appendfsync everysec --save "" --loglevel warning
     volumes:
       - ./data/redis-data:/data
 


### PR DESCRIPTION
## 개요

이슈 #16의 Redis `MISCONF` 오류(RDB 스냅샷 실패로 인한 쓰기 차단)로 설정 변경·갤러리·음성채널 등 기능이 중단되던 문제를 **애플리케이션 회복력(graceful degradation)** + **인프라** 양면에서 해결합니다.

Closes #16

## 변경 사항

### 1. `lib/redis.ts` — best-effort 캐시 계층 + 클라이언트 강화
- `cacheSet` / `cacheGet` 헬퍼 추가: 캐시 쓰기/읽기 실패를 삼키고 경고만 로깅 → 호출부가 DB로 fallback 가능
- 클라이언트에 `retryStrategy`, `reconnectOnError`(네트워크 수준 오류 한정), `maxRetriesPerRequest: 3` 추가
- config 전체를 stdout에 출력하던 `console.log('REDIS CONNECT', config)` 제거 (JWT 시크릿 등 노출 위험 — 부수적 보안 개선)

### 2. `service/setting.ts` — 설정 유실 버그 수정 + 읽기 회복력
- **`setSetting`을 DB 우선 기록으로 재정렬**: 기존엔 캐시를 먼저 써서 `MISCONF` 시 `await redis.set`에서 예외가 발생해 **DB 기록(source of truth)까지 차단**되던 데이터 유실 버그. DB 먼저 기록 후 캐시는 best-effort로 갱신.
- `getSetting`: 캐시 읽기/갱신 실패가 DB 조회 결과 반환을 막지 않도록 `cacheGet`/`cacheSet` 사용

### 3. `service/gallery.ts` — 순수 캐시 → DB fallback
- `getGalleryCategory`의 캐시 읽기/쓰기를 best-effort로 전환

### 4. 음성채널 rename rate-limit 마커 (best-effort 일관화)
- `service/voice-channel/index.ts` 및 `bot/interactions/modals/voice-rename.ts` 양쪽 모두 `cacheSet`으로 전환 (한쪽만 raw `redis.set`이라 `MISCONF` 시 이름 변경 후 처리가 중단되던 불일치 해소 — 리뷰 반영)

### 5. `docker-compose.dev.yml` — 인프라
- Redis를 RDB 스냅샷(`--save 20 1`)에서 **AOF(`--appendonly yes --appendfsync everysec --save ""`)**로 전환
- `--save ""`로 RDB를 비활성화하여 `stop-writes-on-bgsave-error`로 인한 쓰기 차단(MISCONF) 트리거 자체를 제거. AOF가 더 fault-tolerant.

## 의도적으로 변경하지 않은 부분 (후속 과제)

`register.ts`, `auth.ts`, `voice-log.ts`, `ticket.ts`, `voice-channel/redis.ts`(voice owner/data)는 **Redis가 유일한 저장소**입니다. 이들을 best-effort로 바꾸면 상태가 **조용히 유실**되어 더 추적하기 어려운 버그가 됩니다. 이슈의 "장기" 방안인 **DB 이중화**는 스키마 마이그레이션이 필요한 별도 작업이므로 이 PR 범위에서 제외했습니다.

남은 후속 과제(이슈 #16 기준):
- [ ] 핵심 휘발성 상태(회원가입 진행/인증 토큰/음성채널 소유자)의 DB 이중화
- [ ] production 배포 매니페스트에 AOF 및 볼륨/메모리 모니터링·alert
- [ ] Redis 상태 실시간 alert

## 테스트

- `tsc --noEmit` 통과
- `eslint` 통과 (변경 파일 전부)
- `docker compose -f docker-compose.dev.yml config` 유효성 통과
- 변경 파일 prettier 포맷 적용

> 참고: 이 레포지토리에는 테스트 러너가 구성되어 있지 않아 자동화 테스트는 추가하지 않았습니다. 테스트 하네스 도입은 별도 작업으로 권장합니다.

### 수동 검증 TODO
- [ ] `redis-cli config set stop-writes-on-bgsave-error yes` + 디스크 채워 MISCONF 재현 후, 설정 조회/갤러리/음성채널 이름변경이 에러 없이 동작하는지 확인
- [ ] MISCONF 중 `setSetting` 호출 시 DB에 정상 반영되는지 확인
